### PR TITLE
remove specify of MS Mincho

### DIFF
--- a/script/MakeEpub3.py
+++ b/script/MakeEpub3.py
@@ -208,7 +208,7 @@ class osEpub3():
 	def writeVerticalCSS(self, path):
 		css = u'@charset "utf-8";\n'
 		css += u'html {\n'
-		css += u'	font-family: "HiraMinProN-W3", "@ＭＳ 明朝", serif, sans-serif;\n'
+		css += u'	font-family: "HiraMinProN-W3", serif, sans-serif;\n'
 		css += u'	writing-mode: vertical-rl;\n'
 		css += u'	-webkit-writing-mode: vertical-rl;\n'
 		css += u'	-epub-writing-mode: vertical-rl;\n'


### PR DESCRIPTION
(これはたぶん意図的なものだと思うので無視していただいてもかまわないのです)

縦書きフォントとして「@MS 明朝」が指定されていますが、このフォントはアンチエイリアスが効かないので、ディスプレイ上では極めて可読性が低いです。個人的にはここは指定をなくして、ブラウザの標準に任せたほうが良いと思いました(もしくはWindows 8.1から付属している游明朝を指定するか)。
