### PR TITLE
indent writedown section

### DIFF
--- a/default.css
+++ b/default.css
@@ -37,7 +37,7 @@ ol.reference{
 }
 
 .writeDown{
-	font-style:italic;
+	margin-left: 2em;
 }
 
 .deleted{

--- a/script/MakeEpub3.py
+++ b/script/MakeEpub3.py
@@ -229,7 +229,7 @@ class osEpub3():
 		css += u'}\n'
 		
 		css += u'.writeDown{\n'
-		css += u'	font-style:italic;\n'
+		css += u'	margin-top: 2em;\n'
 		css += u'	margin-left: 2em;\n'
 		css += u'	margin-right: 2em;\n'
 		css += u'}\n'


### PR DESCRIPTION
p要素のwriteDown classをイタリック体で表現されていますが、日本語のフォントは斜体で表示されることを前提にデザインされていないことが多いのでとても読みづらいです。代わりに2文字分の字下げで表現してみました。(適当なビューアがないので横書き表示の場合の検証が不十分です、すみません)
